### PR TITLE
Add malformed address tolerance and correctly display chosen apartment complex

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -51,7 +51,9 @@ class App extends React.Component<Props, State> {
         try {
             const location = this.state.currentLocation;
             const workLocation = await bingMapsClient.getLatLng(location.address, location.city, location.state, location.postalCode);
-            const apartmentComplexes = await apartmentsScraper.getApartmentComplexes(location.city, location.state, workLocation);
+            const apartmentComplexes = (await apartmentsScraper.getApartmentComplexes(location.city, location.state, workLocation))
+                .filter(apartmentComplex => apartmentComplex) // Filter out undefined results
+                .map(apartmentComplex => apartmentComplex!); // Assert that the contents are no longer undefined
             console.log("apartmentComplexes:");
             console.log(apartmentComplexes);
             this.setState({

--- a/src/components/Result.tsx
+++ b/src/components/Result.tsx
@@ -3,6 +3,7 @@ import { ApartmentComplexInfo } from "../scraper/ApartmentsScraper";
 
 export interface Props {
     result: ApartmentComplexInfo,
+    index: number
 
     showItems: (index: number) => any
 }
@@ -23,7 +24,7 @@ export class Result extends React.Component<Props, State> {
         return (
             <tr>{Object.keys(this.props.result).map((key, index) => {
                 return <td key={key}>{typeof this.props.result[key] === 'object' ? 
-                    <a className="waves-effect waves-light btn" onClick={_ => this.props.showItems(index)}>items</a>
+                    <a className="waves-effect waves-light btn" onClick={_ => this.props.showItems(this.props.index)}>items</a>
                     : 
                     this.props.result[key]}
                 </td>

--- a/src/components/Results.tsx
+++ b/src/components/Results.tsx
@@ -50,7 +50,9 @@ export class Results extends React.Component<Props, State> {
                     </thead>
 
                     <tbody>
-                        {this.props.results.map(result => <Result key={result.propertyName} result={result} showItems={this.showItems}/>)}
+                        {this.props.results.map((result, index) => 
+                            <Result key={result.propertyName} result={result} showItems={this.showItems} index={index}/>
+                        )}
                     </tbody>
                 </table>
         );

--- a/src/scraper/ApartmentsScraper.ts
+++ b/src/scraper/ApartmentsScraper.ts
@@ -33,7 +33,7 @@ export class ApartmentsScraper {
         this.bingMapsClient = bingMapsClient;
     }
 
-    async getApartmentComplexes (city: string, state: string, workLocation: LocationByAddressResponse): Promise<ApartmentComplexInfo[]> {
+    async getApartmentComplexes (city: string, state: string, workLocation: LocationByAddressResponse): Promise<(ApartmentComplexInfo | undefined)[]> {
         const apartmentComplexLinks = await this.getApartmentComplexLinks(city, state);
         const apartmentInfos = apartmentComplexLinks
             .map(async apartmentLink => await this.getApartmentComplexInfo(apartmentLink, workLocation));
@@ -57,7 +57,7 @@ export class ApartmentsScraper {
             .map(apartmentLink => apartmentLink.attribs.href);
     }
 
-    async getApartmentComplexInfo (link: string, workLocation: LocationByAddressResponse): Promise<ApartmentComplexInfo> {
+    async getApartmentComplexInfo (link: string, workLocation: LocationByAddressResponse): Promise<ApartmentComplexInfo | undefined> {
         const options = {
             uri: link,
             transform: (body: any) => cheerio.load(body)
@@ -106,6 +106,7 @@ export class ApartmentsScraper {
         };
         // Get distance to work
         const apartmentComplexLatLng = await this.bingMapsClient.apartmentComplexLatLng(result);
+        if (!apartmentComplexLatLng) return undefined;
         const distanceMatrix = await this.bingMapsClient.apartmentComplexToWorkDistance(apartmentComplexLatLng, workLocation);
         result.driveDuration = distanceMatrix.resourceSets[0].resources[0].results[0].travelDuration;
         result.driveDistance = distanceMatrix.resourceSets[0].resources[0].results[0].travelDistance;

--- a/src/scraper/BingMapsClient.ts
+++ b/src/scraper/BingMapsClient.ts
@@ -150,14 +150,19 @@ export class BingMapsClient {
         }
     }
 
-    async apartmentComplexLatLng(apartmentComplex: ApartmentComplexInfo | {location: string}) {
+    async apartmentComplexLatLng(apartmentComplex: ApartmentComplexInfo | {location: string}): Promise<LocationByAddressResponse | undefined> {
         const locationString = apartmentComplex.location;
         const locationSplit = locationString.split(",");
-        return this.getLatLng(
-            locationSplit[0],
-            locationSplit[1],
-            locationSplit[2].split(" ")[0],
-            locationSplit[2].split(" ")[1]
-        );
+        try {
+            return this.getLatLng(
+                locationSplit[0],
+                locationSplit[1],
+                locationSplit[2].split(" ")[0],
+                locationSplit[2].split(" ")[1]
+            );
+        } catch (error) {
+            console.error(`Error getting latLng: ${error}`);
+            console.log(`locationString: ${locationString}`);
+        }
     }
 }


### PR DESCRIPTION
If an address result from Bing Maps wasn't in the form <STREET ADDRESS>, <CITY>, <OTHER INFO>, then the parsing wouldn't work correctly. With this PR, addresses not in that form are ignored.

When the "items" button was clicked, it would always show the same apartment complex's listings. This PR fixes this by correctly passing an index in the "onClick" function.